### PR TITLE
Typo and Ignore Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Editor
+*~
+*.swp
+
+# Build files
+Prj-Linux/lpr/TEST_*
+Prj-Linux/*build*/
+*.pyc

--- a/Prj-Linux/lpr/CMakeLists.txt
+++ b/Prj-Linux/lpr/CMakeLists.txt
@@ -3,7 +3,7 @@ project(SwiftPR)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-find_package(OPENCV 3.3.0 REQUIRED)
+find_package(OpenCV 3.3.0 REQUIRED)
 include_directories( ${OpenCV_INCLUDE_DIRS})
 include_directories(include)
 
@@ -53,5 +53,5 @@ target_link_libraries(TEST_SEGMENTATIONFREE ${OpenCV_LIBS})
 
 #TEST_PIPELINE
 
-add_executable(TRST_PIPLINE ${SRC_DETECTION} ${SRC_FINEMAPPING} ${SRC_FASTDESKEW} ${SRC_SEGMENTATION} ${SRC_RECOGNIZE} ${SRC_PIPLINE} ${SRC_SEGMENTATIONFREE} tests/test_pipeline.cpp)
-target_link_libraries(TRST_PIPLINE ${OpenCV_LIBS})
+add_executable(TEST_PIPLINE ${SRC_DETECTION} ${SRC_FINEMAPPING} ${SRC_FASTDESKEW} ${SRC_SEGMENTATION} ${SRC_RECOGNIZE} ${SRC_PIPLINE} ${SRC_SEGMENTATIONFREE} tests/test_pipeline.cpp)
+target_link_libraries(TEST_PIPLINE ${OpenCV_LIBS})


### PR DESCRIPTION
1. Remove a typo in CMakeList.txt.
- In many cmake conf file of many OSs, OpenCV's project name is OpenCV;
- TEST was written as TRST.
2. Ignore build dir, compiled pyc files and editor tmp files.