### PR TITLE
fix JSON serialization error caused by conf=nan

### DIFF
--- a/Prj-Python/hyperlpr3/command/serve.py
+++ b/Prj-Python/hyperlpr3/command/serve.py
@@ -108,8 +108,9 @@ async def vehicle_license_plate_recognition(file: List[UploadFile] = File(...)):
         plates = catcher(img)
         results = list()
         for code, conf, plate_type, box in plates:
-            plate = dict(code=code, conf=float(conf), plate_type=type_list[plate_type], box=box)
-            results.append(plate)
+            if "nan" != f"{conf}":  # conf=nan会导致Json序列化错误
+                plate = dict(code=code, conf=float(conf), plate_type=type_list[plate_type], box=box)
+                results.append(plate)
         return BaseResponse().http_ok_response({'plate_list': results})
 
 


### PR DESCRIPTION
```shell
root@hyperlpr-b78f9ccb5-5jc6t:/app# lpr3 sample -det high -src https://file-prod-1307338471.cos.ap-beijing.myqcloud.com/2024-07-23/1721460714914.jpg
----------------------------------------
/usr/local/lib/python3.6/dist-packages/numpy/core/fromnumeric.py:3373: RuntimeWarning: Mean of empty slice.
  out=out, **kwargs)
/usr/local/lib/python3.6/dist-packages/numpy/core/_methods.py:170: RuntimeWarning: invalid value encountered in double_scalars
  ret = ret.dtype.type(ret / rcount)
2024-07-26 11:39:03.179 | INFO     | hyperlpr3.command.sample:sample:70 - 共检测到车牌: 2
2024-07-26 11:39:03.179 | SUCCESS  | hyperlpr3.command.sample:sample:73 - [蓝牌]粤BF86K7 0.996592104434967 [519, 1286, 888, 1439]
2024-07-26 11:39:03.180 | SUCCESS  | hyperlpr3.command.sample:sample:73 - [蓝牌]AA4M263 nan [1062, 322, 1123, 351]
```